### PR TITLE
Conserta erro de duplicidade na adição de produtos no carrinho

### DIFF
--- a/src/components/AddToCart.jsx
+++ b/src/components/AddToCart.jsx
@@ -1,15 +1,26 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class AddToCart extends Component {
   addToCart = () => {
     const prod = this.props;
-    const productsString = localStorage.getItem('products-on-cart');
+    const productsOnCart = 'products-on-cart';
+    const productsString = localStorage.getItem(productsOnCart);
     let products = [];
     if (productsString) {
       products = JSON.parse(productsString);
+      const checkEqual = products
+        .find((product) => product.product.id === prod.product.id);
+      if (checkEqual) {
+        const oldArray = products
+          .filter((product) => product.product.id !== prod.product.id);
+        checkEqual.quantity += 1;
+        const newArray = [...oldArray, checkEqual];
+        return localStorage.setItem(productsOnCart, JSON.stringify(newArray));
+      }
     }
     products.push({ ...prod, quantity: 1 });
-    localStorage.setItem('products-on-cart', JSON.stringify(products));
+    localStorage.setItem(productsOnCart, JSON.stringify(products));
   }
 
   render() {
@@ -26,3 +37,9 @@ export default class AddToCart extends Component {
     );
   }
 }
+
+AddToCart.propTypes = {
+  product: PropTypes.shape({
+    id: PropTypes.string,
+  }).isRequired,
+};


### PR DESCRIPTION
Conserta erro de duplicidade ao adicionar produtos no carrinho.
Obs: O lint me pediu pra assinalar uma constante pra chave products-on-cart do local storage por tê-la repetido três vezes (linha 7 do arquivo AddToCart).